### PR TITLE
Pass through math code as plain text rather than wrapping in <mathjax> elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 mdx_mathjax.pyc
 README.html
+__pycache__

--- a/mdx_mathjax.py
+++ b/mdx_mathjax.py
@@ -1,21 +1,23 @@
 
 
 import markdown
+import cgi
 
 class MathJaxPattern(markdown.inlinepatterns.Pattern):
 
-    def __init__(self):
-        markdown.inlinepatterns.Pattern.__init__(self, r'(?<!\\)(\$\$?)(.+?)\2')
+    def __init__(self, md):
+        markdown.inlinepatterns.Pattern.__init__(self, r'(?<!\\)(\$\$?)(.+?)\2', md)
 
     def handleMatch(self, m):
-        node = markdown.util.etree.Element('mathjax')
-        node.text = markdown.util.AtomicString(m.group(2) + m.group(3) + m.group(2))
-        return node
+        # Pass the math code through, unmodified except for basic entity substitutions.
+        # Stored in htmlStash so it doesn't get further processed by Markdown.
+        text = cgi.escape(m.group(2) + m.group(3) + m.group(2))
+        return self.markdown.htmlStash.store(text)
 
 class MathJaxExtension(markdown.Extension):
     def extendMarkdown(self, md, md_globals):
         # Needs to come before escape matching because \ is pretty important in LaTeX
-        md.inlinePatterns.add('mathjax', MathJaxPattern(), '<escape')
+        md.inlinePatterns.add('mathjax', MathJaxPattern(md), '<escape')
 
 def makeExtension(configs=[]):
     return MathJaxExtension(configs)


### PR DESCRIPTION
Allows MathJax code to pass straight through to the output without wrapping an HTML element around it. Just a bit cleaner.

This uses the markdown module's "HTML stash" system to store the string so it doesn't get any additional Markdown processing applied. The <, >, and & characters are still translated to entities.

Here it is in action:

```
>>> import markdown, mdx_mathjax
>>> md = markdown.Markdown(extensions=[mdx_mathjax.MathJaxExtension()])
>>> print(md.convert('Hello, world! Here is some math: ${a}_b < c_{d}$'))
<p>Hello, world! Here is some math: ${a}_b &lt; c_{d}$</p>
```
